### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/com/jigdraw/draw/util/Base64Util.java
+++ b/app/src/main/java/com/jigdraw/draw/util/Base64Util.java
@@ -28,7 +28,10 @@ import java.io.ByteArrayOutputStream;
  *
  * @author Jay Paulynice
  */
-public class Base64Util {
+public final class Base64Util {
+
+    private Base64Util() {}
+
     /**
      * Convert bitmap to base 64 string
      *

--- a/app/src/main/java/com/jigdraw/draw/util/DBUtil.java
+++ b/app/src/main/java/com/jigdraw/draw/util/DBUtil.java
@@ -21,7 +21,10 @@ package com.jigdraw.draw.util;
  *
  * @author Jay Paulynice
  */
-public class DBUtil {
+public final class DBUtil {
+
+    private DBUtil() {}
+
     public static final int DATABASE_VERSION = 1;
     public static final String DATABASE_NAME = "jigsaw.db";
     public static final String JIGSAW_TABLE = "jigsaw_images";

--- a/app/src/main/java/com/jigdraw/draw/util/EntityUtil.java
+++ b/app/src/main/java/com/jigdraw/draw/util/EntityUtil.java
@@ -32,7 +32,9 @@ import com.jigdraw.draw.model.ImageEntity;
  *
  * @author Jay Paulynice
  */
-public class EntityUtil {
+public final class EntityUtil {
+
+    private EntityUtil() {}
 
     /**
      * Convert the given image entity to content values

--- a/app/src/main/java/com/jigdraw/draw/util/GridUtil.java
+++ b/app/src/main/java/com/jigdraw/draw/util/GridUtil.java
@@ -18,7 +18,10 @@ package com.jigdraw.draw.util;
 
 import android.view.View;
 
-public class GridUtil {
+public final class GridUtil {
+
+    private GridUtil() {}
+
     public static float getViewX(View view) {
         return Math.abs((view.getRight() - view.getLeft()) / 2);
     }

--- a/app/src/main/java/com/jigdraw/draw/util/ToastUtil.java
+++ b/app/src/main/java/com/jigdraw/draw/util/ToastUtil.java
@@ -24,7 +24,10 @@ import android.widget.Toast;
  *
  * @author Jay Paulynice
  */
-public class ToastUtil {
+public final class ToastUtil {
+
+    private ToastUtil() {}
+
     /**
      * Create short toast and show message
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
Please let me know if you have any questions.
George Kankava