### PR TITLE
Multiple code improvements - squid:UselessParenthesesCheck, squid:SwitchLastCaseIsDefaultCheck, squid:S1444

### DIFF
--- a/app/src/main/java/com/jigdraw/draw/activity/BaseJigsawActivity.java
+++ b/app/src/main/java/com/jigdraw/draw/activity/BaseJigsawActivity.java
@@ -48,6 +48,8 @@ public abstract class BaseJigsawActivity extends Activity {
                 startActivity(new Intent(getApplicationContext(),
                         JigsawHistoryActivity.class));
                 return true;
+            default:
+                break;
         }
         return false;
     }

--- a/app/src/main/java/com/jigdraw/draw/activity/DrawActivity.java
+++ b/app/src/main/java/com/jigdraw/draw/activity/DrawActivity.java
@@ -169,7 +169,7 @@ public class DrawActivity extends BaseJigsawActivity implements OnClickListener 
                 .title(R.string.action_new_drawing)
                 .positiveText(R.string.action_ok)
                 .negativeText(R.string.action_cancel)
-                .content((R.string.action_new_q))
+                .content(R.string.action_new_q)
                 .show();
     }
 

--- a/app/src/main/java/com/jigdraw/draw/util/DBUtil.java
+++ b/app/src/main/java/com/jigdraw/draw/util/DBUtil.java
@@ -53,7 +53,7 @@ public class DBUtil {
     public static final String ORIGINAL_SELECTION_NULL = "original is null";
 
     /** all columns selection */
-    public static String[] ALL_COLUMNS = new String[]{ID_COLUMN, NAME_COLUMN,
+    public final static String[] ALL_COLUMNS = new String[]{ID_COLUMN, NAME_COLUMN,
             IMAGE_COLUMN, DESC_COLUMN, ORIGINAL_COLUMN};
 
     /** arguments to set for the prepared statements */

--- a/app/src/main/java/com/jigdraw/draw/views/JigsawGridView.java
+++ b/app/src/main/java/com/jigdraw/draw/views/JigsawGridView.java
@@ -389,7 +389,7 @@ public class JigsawGridView extends GridView {
     }
 
     private OrderableAdapter getAdapterInterface() {
-        return ((OrderableAdapter) getAdapter());
+        return (OrderableAdapter) getAdapter();
     }
 
     private long getId(int position) {
@@ -578,7 +578,7 @@ public class JigsawGridView extends GridView {
             View view = getViewForId(id);
             if (view != null) {
                 Point targetColumnRowPair = getColumnAndRowForView(view);
-                if ((aboveRight(targetColumnRowPair, mobileColumnRowPair)
+                if (aboveRight(targetColumnRowPair, mobileColumnRowPair)
                         && deltaYTotal < view.getBottom()
                         && deltaXTotal > view.getLeft()
                         || aboveLeft(targetColumnRowPair, mobileColumnRowPair)
@@ -601,7 +601,7 @@ public class JigsawGridView extends GridView {
                         + mOverlapIfSwitchStraightLine || left(
                         targetColumnRowPair, mobileColumnRowPair)
                         && deltaXTotal < view.getRight()
-                        - mOverlapIfSwitchStraightLine)) {
+                        - mOverlapIfSwitchStraightLine) {
                     float xDiff = Math.abs(GridUtil.getViewX(view)
                             - GridUtil.getViewX(mMobileView));
                     float yDiff = Math.abs(GridUtil.getViewY(view)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S1444 - "public static" fields should be constant.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1444
Please let me know if you have any questions.
George Kankava