### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/app/src/main/java/com/jigdraw/draw/util/DBUtil.java
+++ b/app/src/main/java/com/jigdraw/draw/util/DBUtil.java
@@ -23,8 +23,6 @@ package com.jigdraw.draw.util;
  */
 public final class DBUtil {
 
-    private DBUtil() {}
-
     public static final int DATABASE_VERSION = 1;
     public static final String DATABASE_NAME = "jigsaw.db";
     public static final String JIGSAW_TABLE = "jigsaw_images";
@@ -58,6 +56,8 @@ public final class DBUtil {
     /** all columns selection */
     public final static String[] ALL_COLUMNS = new String[]{ID_COLUMN, NAME_COLUMN,
             IMAGE_COLUMN, DESC_COLUMN, ORIGINAL_COLUMN};
+
+    private DBUtil() {}
 
     /** arguments to set for the prepared statements */
     public static String[] getIdArguments(final Long id) {


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava