### PR TITLE
Multiple code improvements - squid:S00117, squid:S1068, squid:S1213

### DIFF
--- a/app/src/main/java/com/jigdraw/draw/service/impl/JigsawServiceImpl.java
+++ b/app/src/main/java/com/jigdraw/draw/service/impl/JigsawServiceImpl.java
@@ -66,13 +66,13 @@ public class JigsawServiceImpl implements JigsawService {
         int w = original.getWidth();
         int h = original.getHeight();
 
-        int tile_width = w / n;
-        int tile_height = h / n;
+        int tileWidth = w / n;
+        int tileHeight = h / n;
 
-        for (int y = 0; y + tile_height <= h; y += tile_height) {
-            for (int x = 0; x + tile_width <= w; x += tile_width) {
-                Bitmap tile = Bitmap.createBitmap(original, x, y, tile_width,
-                        tile_height);
+        for (int y = 0; y + tileHeight <= h; y += tileHeight) {
+            for (int x = 0; x + tileWidth <= w; x += tileWidth) {
+                Bitmap tile = Bitmap.createBitmap(original, x, y, tileWidth,
+                        tileHeight);
                 saveTile(tile, x, y, originalId);
             }
         }

--- a/app/src/main/java/com/jigdraw/draw/views/DrawingView.java
+++ b/app/src/main/java/com/jigdraw/draw/views/DrawingView.java
@@ -43,7 +43,7 @@ public class DrawingView extends View {
     private int paintColor = 0xFF660000;
     private Canvas drawCanvas;
     private Bitmap canvasBitmap;
-    private float brushSize, lastBrushSize;
+    private float brushSize;
 
     /**
      * Create new drawing view with context and attributes and setting up the
@@ -62,7 +62,6 @@ public class DrawingView extends View {
      */
     private void init() {
         brushSize = getResources().getInteger(R.integer.medium_size);
-        lastBrushSize = brushSize;
         drawPath = new Path();
         drawPaint = new Paint();
         drawPaint.setColor(paintColor);
@@ -128,7 +127,6 @@ public class DrawingView extends View {
      * @param newSize the new color
      */
     public void setBrushSize(float newSize) {
-        lastBrushSize = brushSize;
         brushSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,
                 newSize, getResources().getDisplayMetrics());
         drawPaint.setStrokeWidth(brushSize);

--- a/app/src/main/java/com/jigdraw/draw/views/JigsawGridView.java
+++ b/app/src/main/java/com/jigdraw/draw/views/JigsawGridView.java
@@ -181,15 +181,6 @@ public class JigsawGridView extends GridView {
         init(context);
     }
 
-    public void init(Context context) {
-        super.setOnScrollListener(mScrollListener);
-        DisplayMetrics metrics = context.getResources().getDisplayMetrics();
-        mSmoothScrollAmountAtEdge = (int) (SMOOTH_SCROLL_AMOUNT_AT_EDGE
-                * metrics.density + 0.5f);
-        mOverlapIfSwitchStraightLine = getResources().getDimensionPixelSize(
-                R.dimen.dgv_overlap_if_switch_straight_line);
-    }
-
     public JigsawGridView(Context context, AttributeSet attrs) {
         super(context, attrs);
         init(context);
@@ -198,6 +189,15 @@ public class JigsawGridView extends GridView {
     public JigsawGridView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         init(context);
+    }
+
+    public void init(Context context) {
+        super.setOnScrollListener(mScrollListener);
+        DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+        mSmoothScrollAmountAtEdge = (int) (SMOOTH_SCROLL_AMOUNT_AT_EDGE
+                * metrics.density + 0.5f);
+        mOverlapIfSwitchStraightLine = getResources().getDimensionPixelSize(
+                R.dimen.dgv_overlap_if_switch_straight_line);
     }
 
     public static boolean isPreLollipop() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:S1068 - Unused private fields should be removed.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava